### PR TITLE
Potential fix for code scanning alert no. 7: Use of externally-controlled format string

### DIFF
--- a/shared/api/websocket-client.js
+++ b/shared/api/websocket-client.js
@@ -237,7 +237,7 @@ class ChessWebSocketClient {
       try {
         callback(data);
       } catch (error) {
-        console.error(`Error in event listener for ${event}:`, error);
+        console.error('Error in event listener for %s:', event, error);
       }
     });
   }


### PR DESCRIPTION
Potential fix for [https://github.com/RumenDamyanov/js-chess/security/code-scanning/7](https://github.com/RumenDamyanov/js-chess/security/code-scanning/7)

To fix the issue, ensure that user-controlled data (`event`) is not directly interpolated into a format string or template literal in a way that could be misinterpreted or manipulated. The recommended approach is to use a static string with a placeholder (e.g., `%s`) and pass the user-controlled value as a separate argument to the logging function. In this case, change the `console.error` call from using a template literal to using a format string with `%s`, and pass `event` as a separate argument. This ensures that even if `event` contains format specifiers, they will not be interpreted as part of the format string.

Edit only the relevant region in `shared/api/websocket-client.js` (line 240), replacing the template literal with a format string and separate argument. No new imports or dependencies are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
