### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI/CD Pipeline
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/RumenDamyanov/js-chess/security/code-scanning/6](https://github.com/RumenDamyanov/js-chess/security/code-scanning/6)

To fix the problem, you should add a `permissions` block to the workflow file `.github/workflows/ci.yml`. This block can be added at the top level (applies to all jobs) or to individual jobs. The best approach is to add it at the top level, just after the `name:` and before the `on:` block, to ensure all jobs inherit the least privilege unless overridden. For most CI workflows that do not need to write to the repository, the minimal permissions are `contents: read`. If any job needs to create or update pull requests, you can add `pull-requests: write` for that job only. In this case, since the jobs shown do not appear to require write access, set the global permissions to `contents: read`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
